### PR TITLE
buttplug-tampermonkey-ui: Use regular websockets

### DIFF
--- a/utils/buttplug-tampermonkey-ui.js
+++ b/utils/buttplug-tampermonkey-ui.js
@@ -283,7 +283,7 @@ window.addEventListener("load", function (e) {
                }, false);
 
                connect_intiface_button.addEventListener("click", async (event) => {
-                 const connector = new Buttplug.ButtplugBrowserWebsocketClientConnector("wss://localhost:12346/");
+                 const connector = new Buttplug.ButtplugBrowserWebsocketClientConnector("ws://localhost:12345/");
                  await buttplug_client.Connect(connector);
                  connector_div.style.display = "none";
                  enumeration_div.style.display = "block";


### PR DESCRIPTION
Update the websocket connector for buttplug-tampermonkey-ui to use regular websockets on Intiface's default port 12345, since secure websockets were removed in more recent versions of Intiface.